### PR TITLE
[Prevent sync webhooks in checkout bulk queries] Use SyncWebhookControlContext with CheckoutLine

### DIFF
--- a/saleor/graphql/channel/__init__.py
+++ b/saleor/graphql/channel/__init__.py
@@ -1,14 +1,16 @@
 from dataclasses import dataclass
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from django.db.models import QuerySet
+from django.db.models.base import Model
 
-N = TypeVar("N")
+from ..core.context import BaseContext
+
+N = TypeVar("N", bound=Model)
 
 
 @dataclass
-class ChannelContext(Generic[N]):
-    node: N
+class ChannelContext(BaseContext[N]):
     channel_slug: str | None
 
 

--- a/saleor/graphql/channel/types.py
+++ b/saleor/graphql/channel/types.py
@@ -10,7 +10,6 @@ from graphene.types.resolver import get_default_resolver
 from promise import Promise
 
 from ...channel import models
-from ...core.models import ModelWithMetadata
 from ...permission.auth_filters import AuthorizationFilters
 from ...permission.enums import (
     ChannelPermissions,
@@ -101,65 +100,6 @@ class ChannelContextType(ChannelContextTypeForObjectType[T]):
             model = cast(type[Model], root._meta.model._meta.concrete_model)
 
         return model == cls._meta.model
-
-
-TM = TypeVar("TM", bound=ModelWithMetadata)
-
-
-class ChannelContextTypeWithMetadataForObjectType(ChannelContextTypeForObjectType[TM]):
-    """A Graphene type for that uses ChannelContext as root in resolvers.
-
-    Same as ChannelContextType, but for types that implement ObjectWithMetadata
-    interface.
-    """
-
-    class Meta:
-        abstract = True
-
-    @staticmethod
-    def resolve_metadata(root: ChannelContext[TM], info: ResolveInfo):
-        # Used in metadata API to resolve metadata fields from an instance.
-        return ObjectWithMetadata.resolve_metadata(root.node, info)
-
-    @staticmethod
-    def resolve_metafield(root: ChannelContext[TM], info: ResolveInfo, *, key: str):
-        # Used in metadata API to resolve metadata fields from an instance.
-        return ObjectWithMetadata.resolve_metafield(root.node, info, key=key)
-
-    @staticmethod
-    def resolve_metafields(root: ChannelContext[TM], info: ResolveInfo, *, keys=None):
-        # Used in metadata API to resolve metadata fields from an instance.
-        return ObjectWithMetadata.resolve_metafields(root.node, info, keys=keys)
-
-    @staticmethod
-    def resolve_private_metadata(root: ChannelContext[TM], info: ResolveInfo):
-        # Used in metadata API to resolve private metadata fields from an instance.
-        return ObjectWithMetadata.resolve_private_metadata(root.node, info)
-
-    @staticmethod
-    def resolve_private_metafield(
-        root: ChannelContext[TM], info: ResolveInfo, *, key: str
-    ):
-        # Used in metadata API to resolve private metadata fields from an instance.
-        return ObjectWithMetadata.resolve_private_metafield(root.node, info, key=key)
-
-    @staticmethod
-    def resolve_private_metafields(
-        root: ChannelContext[TM], info: ResolveInfo, *, keys=None
-    ):
-        # Used in metadata API to resolve private metadata fields from an instance.
-        return ObjectWithMetadata.resolve_private_metafields(root.node, info, keys=keys)
-
-
-class ChannelContextTypeWithMetadata(ChannelContextTypeWithMetadataForObjectType[TM]):
-    """A Graphene type for that uses ChannelContext as root in resolvers.
-
-    Same as ChannelContextType, but for types that implement ObjectWithMetadata
-    interface.
-    """
-
-    class Meta:
-        abstract = True
 
 
 class StockSettings(BaseObjectType):

--- a/saleor/graphql/checkout/schema.py
+++ b/saleor/graphql/checkout/schema.py
@@ -7,7 +7,6 @@ from ...permission.enums import (
 )
 from ..core import ResolveInfo
 from ..core.connection import (
-    create_connection_slice,
     create_connection_slice_for_sync_webhook_control_context,
     filter_connection_queryset,
 )
@@ -107,8 +106,8 @@ class CheckoutQueries(graphene.ObjectType):
     @staticmethod
     def resolve_checkout_lines(_root, info: ResolveInfo, **kwargs):
         qs = resolve_checkout_lines(info)
-        return create_connection_slice(
-            qs, info, kwargs, CheckoutLineCountableConnection
+        return create_connection_slice_for_sync_webhook_control_context(
+            qs, info, kwargs, CheckoutLineCountableConnection, allow_sync_webhooks=False
         )
 
 

--- a/saleor/graphql/checkout/tests/test_checkout.py
+++ b/saleor/graphql/checkout/tests/test_checkout.py
@@ -3604,6 +3604,27 @@ CHECKOUTS_QUERY = """
 """
 
 
+CHECKOUTS_WITH_LINES_TOTAL_PRICE_QUERY = """
+    {
+        checkouts(first: 20) {
+            edges {
+                node {
+                    token
+                    lines{
+                        totalPrice {
+                            currency
+                            gross {
+                                amount
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"""
+
+
 def test_staff_user_can_query_checkouts_with_handle_payments_permission(
     checkout_with_item, staff_api_client, permission_manage_payments
 ):
@@ -3661,6 +3682,9 @@ def test_query_checkouts(
     assert str(checkout.token) == received_checkout["token"]
 
 
+@pytest.mark.parametrize(
+    "query", [CHECKOUTS_QUERY, CHECKOUTS_WITH_LINES_TOTAL_PRICE_QUERY]
+)
 @mock.patch(
     "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
     wraps=_fetch_checkout_prices_if_expired,
@@ -3669,6 +3693,7 @@ def test_query_checkouts(
 def test_query_checkouts_do_not_trigger_sync_tax_webhooks(
     mocked_calculate_and_add_tax,
     mocked_fetch_checkout_prices_if_expired,
+    query,
     checkout_with_item,
     staff_api_client,
     permission_manage_checkouts,
@@ -3681,7 +3706,7 @@ def test_query_checkouts_do_not_trigger_sync_tax_webhooks(
 
     # when
     response = staff_api_client.post_graphql(
-        CHECKOUTS_QUERY, {}, permissions=[permission_manage_checkouts]
+        query, {}, permissions=[permission_manage_checkouts]
     )
 
     # then
@@ -3703,6 +3728,9 @@ def test_query_checkouts_do_not_trigger_sync_tax_webhooks(
     )
 
 
+@pytest.mark.parametrize(
+    "query", [CHECKOUTS_QUERY, CHECKOUTS_WITH_LINES_TOTAL_PRICE_QUERY]
+)
 @mock.patch(
     "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
     wraps=_fetch_checkout_prices_if_expired,
@@ -3711,6 +3739,7 @@ def test_query_checkouts_do_not_trigger_sync_tax_webhooks(
 def test_query_checkouts_calculate_flat_taxes(
     mocked_update_order_prices_with_flat_rates,
     mocked_fetch_checkout_prices_if_expired,
+    query,
     checkout_with_item,
     staff_api_client,
     permission_manage_checkouts,
@@ -3723,7 +3752,7 @@ def test_query_checkouts_calculate_flat_taxes(
 
     # when
     response = staff_api_client.post_graphql(
-        CHECKOUTS_QUERY, {}, permissions=[permission_manage_checkouts]
+        query, {}, permissions=[permission_manage_checkouts]
     )
 
     # then
@@ -3785,6 +3814,116 @@ def test_query_without_channel(
     # then
     content = get_graphql_content(response)
     assert len(content["data"]["checkouts"]["edges"]) == 5
+
+
+CHECKOUT_LINES_WITH_TOTAL_PRICE = """
+{
+    checkoutLines(first: 20) {
+        edges {
+            node {
+                id
+                totalPrice {
+                    currency
+                    gross {
+                        amount
+                    }
+                }
+            }
+        }
+    }
+}
+"""
+
+
+@mock.patch(
+    "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
+    wraps=_fetch_checkout_prices_if_expired,
+)
+@mock.patch("saleor.checkout.calculations._calculate_and_add_tax")
+def test_query_checkout_lines_do_not_trigger_sync_tax_webhooks(
+    mocked_calculate_and_add_tax,
+    mocked_fetch_checkout_prices_if_expired,
+    checkout_with_item,
+    staff_api_client,
+    permission_manage_checkouts,
+    tax_configuration_tax_app,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.price_expiration = timezone.now()
+    checkout.save()
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHECKOUT_LINES_WITH_TOTAL_PRICE, {}, permissions=[permission_manage_checkouts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["checkoutLines"]["edges"])
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    mocked_calculate_and_add_tax.assert_not_called()
+    mocked_fetch_checkout_prices_if_expired.assert_called_once_with(
+        checkout_info=mock.ANY,
+        allow_sync_webhooks=False,
+        address=None,
+        database_connection_name=mock.ANY,
+        force_update=False,
+        lines=lines,
+        manager=mock.ANY,
+        pregenerated_subscription_payloads=mock.ANY,
+    )
+
+
+@mock.patch(
+    "saleor.checkout.calculations._fetch_checkout_prices_if_expired",
+    wraps=_fetch_checkout_prices_if_expired,
+)
+@mock.patch("saleor.checkout.calculations.update_checkout_prices_with_flat_rates")
+def test_query_checkout_lines_calculate_flat_taxes(
+    mocked_update_order_prices_with_flat_rates,
+    mocked_fetch_checkout_prices_if_expired,
+    checkout_with_item,
+    staff_api_client,
+    permission_manage_checkouts,
+    tax_configuration_flat_rates,
+):
+    # given
+    checkout = checkout_with_item
+    checkout.price_expiration = timezone.now()
+    checkout.save()
+
+    # when
+    response = staff_api_client.post_graphql(
+        CHECKOUT_LINES_WITH_TOTAL_PRICE, {}, permissions=[permission_manage_checkouts]
+    )
+
+    # then
+    content = get_graphql_content(response)
+    assert len(content["data"]["checkoutLines"]["edges"])
+
+    lines, _ = fetch_checkout_lines(checkout_with_item)
+
+    mocked_update_order_prices_with_flat_rates.assert_called_once_with(
+        checkout_with_item,
+        mock.ANY,
+        lines,
+        tax_configuration_flat_rates.prices_entered_with_tax,
+        None,
+        database_connection_name=mock.ANY,
+    )
+    mocked_fetch_checkout_prices_if_expired.assert_called_once_with(
+        checkout_info=mock.ANY,
+        allow_sync_webhooks=False,
+        address=None,
+        database_connection_name=mock.ANY,
+        force_update=False,
+        lines=lines,
+        manager=mock.ANY,
+        pregenerated_subscription_payloads=mock.ANY,
+    )
 
 
 def test_query_checkout_lines(

--- a/saleor/graphql/checkout/types.py
+++ b/saleor/graphql/checkout/types.py
@@ -51,8 +51,11 @@ from ..core.enums import LanguageCodeEnum
 from ..core.fields import BaseField, PermissionsField
 from ..core.scalars import UUID, DateTime, PositiveDecimal
 from ..core.tracing import traced_resolver
-from ..core.types import BaseObjectType, ModelObjectType, Money, NonNullList, TaxedMoney
-from ..core.types.sync_webhook_control import SyncWebhookControlContextType
+from ..core.types import Money, NonNullList, TaxedMoney
+from ..core.types.sync_webhook_control import (
+    SyncWebhookControlContextModelObjectType,
+    SyncWebhookControlContextObjectType,
+)
 from ..core.utils import CHECKOUT_CALCULATE_TAXES_MESSAGE, WebhookEventInfo, str_to_enum
 from ..decorators import one_of_permissions_required
 from ..discount.dataloaders import VoucherByCodeLoader
@@ -120,7 +123,7 @@ def get_dataloaders_for_fetching_checkout_data(
 
 
 class CheckoutLineProblemInsufficientStock(
-    BaseObjectType,
+    SyncWebhookControlContextObjectType[problems.CheckoutLineProblemInsufficientStock],
 ):
     available_quantity = graphene.Int(description="Available quantity of a variant.")
     line = graphene.Field(
@@ -135,14 +138,26 @@ class CheckoutLineProblemInsufficientStock(
     )
 
     class Meta:
+        default_resolver = SyncWebhookControlContextObjectType.resolver_with_context
         description = (
             "Indicates insufficient stock for a given checkout line."
             "Placing the order will not be possible until solving this problem."
         )
         doc_category = DOC_CATEGORY_CHECKOUT
 
+    @staticmethod
+    def resolve_line(
+        root: SyncWebhookControlContext[problems.CheckoutLineProblemInsufficientStock],
+        _info: ResolveInfo,
+    ):
+        return SyncWebhookControlContext(
+            node=root.node.line, allow_sync_webhooks=root.allow_sync_webhooks
+        )
 
-class CheckoutLineProblemVariantNotAvailable(BaseObjectType):
+
+class CheckoutLineProblemVariantNotAvailable(
+    SyncWebhookControlContextObjectType[problems.CheckoutLineProblemVariantNotAvailable]
+):
     line = graphene.Field(
         "saleor.graphql.checkout.types.CheckoutLine",
         description="The line that has variant that is not available.",
@@ -156,6 +171,33 @@ class CheckoutLineProblemVariantNotAvailable(BaseObjectType):
         )
         doc_category = DOC_CATEGORY_CHECKOUT
 
+    @staticmethod
+    def resolve_line(
+        root: SyncWebhookControlContext[
+            problems.CheckoutLineProblemVariantNotAvailable
+        ],
+        _info: ResolveInfo,
+    ):
+        return SyncWebhookControlContext(
+            node=root.node.line, allow_sync_webhooks=root.allow_sync_webhooks
+        )
+
+
+def _resolve_line_problem_type(
+    instance: SyncWebhookControlContext[problems.CHECKOUT_PROBLEM_TYPE],
+) -> (
+    type[CheckoutLineProblemInsufficientStock]
+    | type[CheckoutLineProblemVariantNotAvailable]
+    | None
+):
+    problem_instance = instance.node
+
+    if isinstance(problem_instance, problems.CheckoutLineProblemInsufficientStock):
+        return CheckoutLineProblemInsufficientStock
+    if isinstance(problem_instance, problems.CheckoutLineProblemVariantNotAvailable):
+        return CheckoutLineProblemVariantNotAvailable
+    return None
+
 
 class CheckoutLineProblem(graphene.Union):
     class Meta:
@@ -167,12 +209,15 @@ class CheckoutLineProblem(graphene.Union):
         doc_category = DOC_CATEGORY_CHECKOUT
 
     @classmethod
-    def resolve_type(cls, instance: problems.CHECKOUT_PROBLEM_TYPE, info: ResolveInfo):
-        if isinstance(instance, problems.CheckoutLineProblemInsufficientStock):
-            return CheckoutLineProblemInsufficientStock
-        if isinstance(instance, problems.CheckoutLineProblemVariantNotAvailable):
-            return CheckoutLineProblemVariantNotAvailable
-        return super().resolve_type(instance, info)
+    def resolve_type(
+        cls,
+        instance: SyncWebhookControlContext[problems.CHECKOUT_PROBLEM_TYPE],
+        info: ResolveInfo,
+    ):
+        problem_type = _resolve_line_problem_type(instance)
+        if problem_type:
+            return problem_type
+        return super().resolve_type(instance.node, info)
 
 
 class CheckoutProblem(graphene.Union):
@@ -183,16 +228,17 @@ class CheckoutProblem(graphene.Union):
 
     @classmethod
     def resolve_type(
-        cls, instance: problems.CHECKOUT_LINE_PROBLEM_TYPE, info: ResolveInfo
+        cls,
+        instance: SyncWebhookControlContext[problems.CHECKOUT_PROBLEM_TYPE],
+        info: ResolveInfo,
     ):
-        if isinstance(instance, problems.CheckoutLineProblemInsufficientStock):
-            return CheckoutLineProblemInsufficientStock
-        if isinstance(instance, problems.CheckoutLineProblemVariantNotAvailable):
-            return CheckoutLineProblemVariantNotAvailable
-        return super().resolve_type(instance, info)
+        line_problem_type = _resolve_line_problem_type(instance)
+        if line_problem_type:
+            return line_problem_type
+        return super().resolve_type(instance.node, info)
 
 
-class CheckoutLine(ModelObjectType[models.CheckoutLine]):
+class CheckoutLine(SyncWebhookControlContextModelObjectType[models.CheckoutLine]):
     id = graphene.GlobalID(required=True, description="The ID of the checkout line.")
     variant = graphene.Field(
         "saleor.graphql.product.types.ProductVariant",
@@ -247,14 +293,19 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
     )
 
     class Meta:
+        default_resolver = (
+            SyncWebhookControlContextModelObjectType.resolver_with_context
+        )
         description = "Represents an item in the checkout."
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
         model = models.CheckoutLine
 
     @staticmethod
-    def resolve_variant(root: models.CheckoutLine, info: ResolveInfo):
-        variant = ProductVariantByIdLoader(info.context).load(root.variant_id)
-        channel = ChannelByCheckoutIDLoader(info.context).load(root.checkout_id)
+    def resolve_variant(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
+        variant = ProductVariantByIdLoader(info.context).load(root.node.variant_id)
+        channel = ChannelByCheckoutIDLoader(info.context).load(root.node.checkout_id)
 
         return Promise.all([variant, channel]).then(
             lambda data: ChannelContext(node=data[0], channel_slug=data[1].slug)
@@ -262,7 +313,9 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
 
     @staticmethod
     @prevent_sync_event_circular_query
-    def resolve_unit_price(root, info: ResolveInfo):
+    def resolve_unit_price(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
         def with_checkout(data):
             checkout, manager = data
             checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
@@ -280,7 +333,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 checkout_info, lines, payloads = data
                 database_connection_name = get_database_connection_name(info.context)
                 for line_info in lines:
-                    if line_info.line.pk == root.pk:
+                    if line_info.line.pk == root.node.pk:
                         return calculations.checkout_line_unit_price(
                             manager=manager,
                             checkout_info=checkout_info,
@@ -288,6 +341,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                             checkout_line_info=line_info,
                             database_connection_name=database_connection_name,
                             pregenerated_subscription_payloads=payloads,
+                            allow_sync_webhooks=root.allow_sync_webhooks,
                         )
                 return None
 
@@ -301,13 +355,15 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
 
         return Promise.all(
             [
-                CheckoutByTokenLoader(info.context).load(root.checkout_id),
+                CheckoutByTokenLoader(info.context).load(root.node.checkout_id),
                 get_plugin_manager_promise(info.context),
             ]
         ).then(with_checkout)
 
     @staticmethod
-    def resolve_undiscounted_unit_price(root, info: ResolveInfo):
+    def resolve_undiscounted_unit_price(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
         def with_checkout(checkout):
             checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
                 checkout.token
@@ -322,7 +378,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                     lines,
                 ) = data
                 for line_info in lines:
-                    if line_info.line.pk == root.pk:
+                    if line_info.line.pk == root.node.pk:
                         return calculations.checkout_line_undiscounted_unit_price(
                             checkout_info=checkout_info,
                             checkout_line_info=line_info,
@@ -339,14 +395,16 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
 
         return (
             CheckoutByTokenLoader(info.context)
-            .load(root.checkout_id)
+            .load(root.node.checkout_id)
             .then(with_checkout)
         )
 
     @staticmethod
     @traced_resolver
     @prevent_sync_event_circular_query
-    def resolve_total_price(root, info: ResolveInfo):
+    def resolve_total_price(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
         def with_checkout(data):
             checkout, manager = data
             checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
@@ -364,7 +422,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                 checkout_info, lines, payloads = data
                 database_connection_name = get_database_connection_name(info.context)
                 for line_info in lines:
-                    if line_info.line.pk == root.pk:
+                    if line_info.line.pk == root.node.pk:
                         return calculations.checkout_line_total(
                             manager=manager,
                             checkout_info=checkout_info,
@@ -372,6 +430,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                             checkout_line_info=line_info,
                             database_connection_name=database_connection_name,
                             pregenerated_subscription_payloads=payloads,
+                            allow_sync_webhooks=root.allow_sync_webhooks,
                         )
                 return None
 
@@ -385,13 +444,15 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
 
         return Promise.all(
             [
-                CheckoutByTokenLoader(info.context).load(root.checkout_id),
+                CheckoutByTokenLoader(info.context).load(root.node.checkout_id),
                 get_plugin_manager_promise(info.context),
             ]
         ).then(with_checkout)
 
     @staticmethod
-    def resolve_undiscounted_total_price(root, info: ResolveInfo):
+    def resolve_undiscounted_total_price(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
         def with_checkout(checkout):
             checkout_info = CheckoutInfoByCheckoutTokenLoader(info.context).load(
                 checkout.token
@@ -406,7 +467,7 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
                     lines,
                 ) = data
                 for line_info in lines:
-                    if line_info.line.pk == root.pk:
+                    if line_info.line.pk == root.node.pk:
                         return calculations.checkout_line_undiscounted_total_price(
                             checkout_info=checkout_info,
                             checkout_line_info=line_info,
@@ -422,30 +483,40 @@ class CheckoutLine(ModelObjectType[models.CheckoutLine]):
 
         return (
             CheckoutByTokenLoader(info.context)
-            .load(root.checkout_id)
+            .load(root.node.checkout_id)
             .then(with_checkout)
         )
 
     @staticmethod
-    def resolve_requires_shipping(root: models.CheckoutLine, info: ResolveInfo):
+    def resolve_requires_shipping(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
         def is_shipping_required(product_type):
             return product_type.is_shipping_required
 
         return (
             ProductTypeByVariantIdLoader(info.context)
-            .load(root.variant_id)
+            .load(root.node.variant_id)
             .then(is_shipping_required)
         )
 
     @staticmethod
     @traced_resolver
-    def resolve_problems(root: models.CheckoutLine, info: ResolveInfo):
+    def resolve_problems(
+        root: SyncWebhookControlContext[models.CheckoutLine], info: ResolveInfo
+    ):
         problems_dataloader = CheckoutLinesProblemsByCheckoutIdLoader(
             info.context
-        ).load(root.checkout_id)
+        ).load(root.node.checkout_id)
 
         def get_problem_for_line(problems):
-            return problems.get(str(root.pk), [])
+            line_problems = problems.get(str(root.node.pk), [])
+            return [
+                SyncWebhookControlContext(
+                    node=problem, allow_sync_webhooks=root.allow_sync_webhooks
+                )
+                for problem in line_problems
+            ]
 
         return problems_dataloader.then(get_problem_for_line)
 
@@ -475,7 +546,7 @@ class DeliveryMethod(graphene.Union):
         return super().resolve_type(instance, info)
 
 
-class Checkout(SyncWebhookControlContextType[models.Checkout]):
+class Checkout(SyncWebhookControlContextModelObjectType[models.Checkout]):
     id = graphene.ID(required=True, description="The ID of the checkout.")
     created = DateTime(
         required=True, description="The date and time when the checkout was created."
@@ -781,7 +852,9 @@ class Checkout(SyncWebhookControlContextType[models.Checkout]):
     )
 
     class Meta:
-        default_resolver = SyncWebhookControlContextType.resolver_with_context
+        default_resolver = (
+            SyncWebhookControlContextModelObjectType.resolver_with_context
+        )
         description = "Checkout object."
         model = models.Checkout
         interfaces = [graphene.relay.Node, ObjectWithMetadata]
@@ -979,7 +1052,19 @@ class Checkout(SyncWebhookControlContextType[models.Checkout]):
     def resolve_lines(
         root: SyncWebhookControlContext[models.Checkout], info: ResolveInfo
     ):
-        return CheckoutLinesByCheckoutTokenLoader(info.context).load(root.node.token)
+        def _wrap_with_sync_webhook_control_context(lines):
+            return [
+                SyncWebhookControlContext(
+                    node=line, allow_sync_webhooks=root.allow_sync_webhooks
+                )
+                for line in lines
+            ]
+
+        return (
+            CheckoutLinesByCheckoutTokenLoader(info.context)
+            .load(root.node.token)
+            .then(_wrap_with_sync_webhook_control_context)
+        )
 
     @staticmethod
     @traced_resolver
@@ -1237,14 +1322,6 @@ class Checkout(SyncWebhookControlContextType[models.Checkout]):
         )
 
     @classmethod
-    # FIXME: this probably can be dropped and implemented in `saleor.graphql.meta.types.ObjectWithMetadata.resolve_type`
-    def resolve_type(cls, root: SyncWebhookControlContext[models.Checkout], _info):
-        item_type, _ = MetaResolvers.resolve_object_with_metadata_type(
-            root.node.metadata_storage
-        )
-        return item_type
-
-    @classmethod
     def resolve_updated_at(
         cls, root: SyncWebhookControlContext[models.Checkout], _info
     ):
@@ -1337,13 +1414,24 @@ class Checkout(SyncWebhookControlContextType[models.Checkout]):
         checkout_problems_dataloader = CheckoutProblemsByCheckoutIdDataloader(
             info.context
         )
-        return checkout_problems_dataloader.load(root.node.pk)
+
+        def _wrapped_with_sync_webhook_control_context(problems):
+            return [
+                SyncWebhookControlContext(
+                    node=problem, allow_sync_webhooks=root.allow_sync_webhooks
+                )
+                for problem in problems
+            ]
+
+        return checkout_problems_dataloader.load(root.node.pk).then(
+            _wrapped_with_sync_webhook_control_context
+        )
 
     @staticmethod
     def resolve_stored_payment_methods(
         root: SyncWebhookControlContext[models.Checkout],
         info: ResolveInfo,
-        amount: Decimal | None = None
+        amount: Decimal | None = None,
     ):
         user_id = root.node.user_id
         if user_id is None:

--- a/saleor/graphql/core/context.py
+++ b/saleor/graphql/core/context.py
@@ -71,6 +71,10 @@ N = TypeVar("N")
 
 
 @dataclass
-class SyncWebhookControlContext(Generic[N]):
+class BaseContext(Generic[N]):
     node: N
+
+
+@dataclass
+class SyncWebhookControlContext(BaseContext[N]):
     allow_sync_webhooks: bool = True

--- a/saleor/graphql/core/types/sync_webhook_control.py
+++ b/saleor/graphql/core/types/sync_webhook_control.py
@@ -1,16 +1,17 @@
-from typing import TypeVar
+from typing import Generic, TypeVar
 
 from django.db.models import Model
 from graphene.types.resolver import get_default_resolver
 
 from .. import ResolveInfo
 from ..context import SyncWebhookControlContext
+from . import BaseObjectType
 from .model import ModelObjectType
 
-T = TypeVar("T", bound=Model)
+N = TypeVar("N")
 
 
-class SyncWebhookControlContextType(ModelObjectType[T]):
+class SyncWebhookControlContextObjectType(Generic[N], BaseObjectType):
     class Meta:
         abstract = True
 
@@ -18,9 +19,19 @@ class SyncWebhookControlContextType(ModelObjectType[T]):
     def resolver_with_context(
         attname,
         default_value,
-        root: SyncWebhookControlContext,
+        root: SyncWebhookControlContext[N],
         info: ResolveInfo,
         **args,
     ):
         resolver = get_default_resolver()
         return resolver(attname, default_value, root.node, info, **args)
+
+
+T = TypeVar("T", bound=Model)
+
+
+class SyncWebhookControlContextModelObjectType(
+    ModelObjectType[T], SyncWebhookControlContextObjectType[T]
+):
+    class Meta:
+        abstract = True

--- a/saleor/graphql/core/types/taxes.py
+++ b/saleor/graphql/core/types/taxes.py
@@ -58,6 +58,8 @@ class TaxSourceLine(graphene.Union):
 
     @classmethod
     def resolve_type(cls, instance, info: ResolveInfo):
+        if isinstance(instance, SyncWebhookControlContext):
+            instance = instance.node
         if isinstance(instance, CheckoutLine):
             return checkout_types.CheckoutLine
         if isinstance(instance, OrderLine):
@@ -154,6 +156,8 @@ class TaxableObjectLine(BaseObjectType):
 
     @staticmethod
     def resolve_source_line(root: CheckoutLine | OrderLine, _info: ResolveInfo):
+        if isinstance(root, CheckoutLine):
+            return SyncWebhookControlContext(node=root)
         return root
 
     @staticmethod

--- a/saleor/graphql/discount/types/sales.py
+++ b/saleor/graphql/discount/types/sales.py
@@ -6,12 +6,7 @@ from ....permission.enums import DiscountPermissions
 from ....product.models import Category, Collection, Product, ProductVariant
 from ...channel import ChannelQsContext
 from ...channel.dataloaders import ChannelBySlugLoader
-from ...channel.types import (
-    Channel,
-    ChannelContext,
-    ChannelContextType,
-    ChannelContextTypeWithMetadata,
-)
+from ...channel.types import Channel, ChannelContext, ChannelContextType
 from ...core import ResolveInfo
 from ...core.connection import CountableConnection, create_connection_slice
 from ...core.context import get_database_connection_name
@@ -64,7 +59,7 @@ class SaleChannelListing(BaseObjectType):
         doc_category = DOC_CATEGORY_DISCOUNTS
 
 
-class Sale(ChannelContextTypeWithMetadata, ModelObjectType[models.Promotion]):
+class Sale(ChannelContextType, ModelObjectType[models.Promotion]):
     id = graphene.GlobalID(required=True, description="The ID of the sale.")
     name = graphene.String(required=True, description="The name of the sale.")
     type = SaleType(required=True, description="Type of the sale, fixed or percentage.")

--- a/saleor/graphql/discount/types/vouchers.py
+++ b/saleor/graphql/discount/types/vouchers.py
@@ -5,20 +5,11 @@ from ....discount import models
 from ....permission.enums import DiscountPermissions
 from ...channel import ChannelQsContext
 from ...channel.dataloaders import ChannelByIdLoader
-from ...channel.types import (
-    Channel,
-    ChannelContext,
-    ChannelContextType,
-    ChannelContextTypeWithMetadata,
-)
+from ...channel.types import Channel, ChannelContext, ChannelContextType
 from ...core import ResolveInfo, types
 from ...core.connection import CountableConnection, create_connection_slice
 from ...core.context import get_database_connection_name
-from ...core.descriptions import (
-    ADDED_IN_318,
-    DEPRECATED_IN_3X_FIELD,
-    PREVIEW_FEATURE,
-)
+from ...core.descriptions import ADDED_IN_318, DEPRECATED_IN_3X_FIELD, PREVIEW_FEATURE
 from ...core.doc_category import DOC_CATEGORY_DISCOUNTS
 from ...core.fields import ConnectionField, PermissionsField
 from ...core.scalars import DateTime
@@ -86,7 +77,7 @@ class VoucherCodeCountableConnection(CountableConnection):
         node = VoucherCode
 
 
-class Voucher(ChannelContextTypeWithMetadata[models.Voucher]):
+class Voucher(ChannelContextType[models.Voucher]):
     id = graphene.GlobalID(required=True, description="The ID of the voucher.")
     name = graphene.String(description="The name of the voucher.")
     codes = ConnectionField(
@@ -264,9 +255,9 @@ class Voucher(ChannelContextTypeWithMetadata[models.Voucher]):
             VoucherChannelListingByVoucherIdAndChannelSlugLoader(info.context)
             .load((root.node.id, root.channel_slug))
             .then(
-                lambda channel_listing: channel_listing.discount_value
-                if channel_listing
-                else None
+                lambda channel_listing: (
+                    channel_listing.discount_value if channel_listing else None
+                )
             )
         )
 
@@ -279,9 +270,9 @@ class Voucher(ChannelContextTypeWithMetadata[models.Voucher]):
             VoucherChannelListingByVoucherIdAndChannelSlugLoader(info.context)
             .load((root.node.id, root.channel_slug))
             .then(
-                lambda channel_listing: channel_listing.currency
-                if channel_listing
-                else None
+                lambda channel_listing: (
+                    channel_listing.currency if channel_listing else None
+                )
             )
         )
 
@@ -294,9 +285,9 @@ class Voucher(ChannelContextTypeWithMetadata[models.Voucher]):
             VoucherChannelListingByVoucherIdAndChannelSlugLoader(info.context)
             .load((root.node.id, root.channel_slug))
             .then(
-                lambda channel_listing: channel_listing.min_spent
-                if channel_listing
-                else None
+                lambda channel_listing: (
+                    channel_listing.min_spent if channel_listing else None
+                )
             )
         )
 

--- a/saleor/graphql/menu/types.py
+++ b/saleor/graphql/menu/types.py
@@ -6,11 +6,7 @@ from ...permission.enums import PagePermissions
 from ...permission.utils import has_one_of_permissions
 from ...product.models import ALL_PRODUCTS_PERMISSIONS
 from ..channel.dataloaders import ChannelBySlugLoader
-from ..channel.types import (
-    ChannelContext,
-    ChannelContextType,
-    ChannelContextTypeWithMetadata,
-)
+from ..channel.types import ChannelContext, ChannelContextType
 from ..core import ResolveInfo
 from ..core.connection import CountableConnection
 from ..core.doc_category import DOC_CATEGORY_MENU
@@ -35,7 +31,7 @@ from .dataloaders import (
 )
 
 
-class Menu(ChannelContextTypeWithMetadata[models.Menu]):
+class Menu(ChannelContextType[models.Menu]):
     id = graphene.GlobalID(required=True, description="The ID of the menu.")
     name = graphene.String(required=True, description="The name of the menu.")
     slug = graphene.String(required=True, description="Slug of the menu.")
@@ -69,7 +65,7 @@ class MenuCountableConnection(CountableConnection):
         node = Menu
 
 
-class MenuItem(ChannelContextTypeWithMetadata[models.MenuItem]):
+class MenuItem(ChannelContextType[models.MenuItem]):
     id = graphene.GlobalID(required=True, description="The ID of the menu item.")
     name = graphene.String(required=True, description="The name of the menu item.")
     menu = graphene.Field(
@@ -156,11 +152,11 @@ class MenuItem(ChannelContextTypeWithMetadata[models.MenuItem]):
                 CollectionByIdLoader(info.context)
                 .load(root.node.collection_id)
                 .then(
-                    lambda collection: ChannelContext(
-                        node=collection, channel_slug=root.channel_slug
+                    lambda collection: (
+                        ChannelContext(node=collection, channel_slug=root.channel_slug)
+                        if collection
+                        else None
                     )
-                    if collection
-                    else None
                 )
             )
 
@@ -184,11 +180,11 @@ class MenuItem(ChannelContextTypeWithMetadata[models.MenuItem]):
                     CollectionByIdLoader(info.context)
                     .load(root.node.collection_id)
                     .then(
-                        lambda collection: ChannelContext(
-                            node=collection, channel_slug=channel_slug
+                        lambda collection: (
+                            ChannelContext(node=collection, channel_slug=channel_slug)
+                            if collection
+                            else None
                         )
-                        if collection
-                        else None
                     )
                 )
 
@@ -231,9 +227,9 @@ class MenuItem(ChannelContextTypeWithMetadata[models.MenuItem]):
                 PageByIdLoader(info.context)
                 .load(root.node.page_id)
                 .then(
-                    lambda page: page
-                    if requestor_has_access_to_all or page.is_visible
-                    else None
+                    lambda page: (
+                        page if requestor_has_access_to_all or page.is_visible else None
+                    )
                 )
             )
         return None

--- a/saleor/graphql/meta/resolvers.py
+++ b/saleor/graphql/meta/resolvers.py
@@ -47,45 +47,46 @@ def resolve_object_with_metadata_type(instance):
     from ..tax import types as tax_types
     from ..warehouse import types as warehouse_types
 
-    if isinstance(instance, ModelWithMetadata):
-        MODEL_TO_TYPE_MAP = {
-            account_models.Address: account_types.Address,
-            account_models.User: account_types.User,
-            app_models.App: app_types.App,
-            attribute_models.Attribute: attribute_types.Attribute,
-            channel_models.Channel: channel_types.Channel,
-            checkout_models.Checkout: checkout_types.Checkout,
-            checkout_models.CheckoutMetadata: checkout_types.Checkout,
-            checkout_models.CheckoutLine: checkout_types.CheckoutLine,
-            discount_models.Promotion: discount_types.Promotion,
-            discount_models.Voucher: discount_types.Voucher,
-            giftcard_models.GiftCard: giftcard_types.GiftCard,
-            invoice_models.Invoice: invoice_types.Invoice,
-            menu_models.Menu: menu_types.Menu,
-            menu_models.MenuItem: menu_types.MenuItem,
-            order_models.Fulfillment: order_types.Fulfillment,
-            order_models.Order: order_types.Order,
-            order_models.OrderLine: order_types.OrderLine,
-            page_models.Page: page_types.Page,
-            page_models.PageType: page_types.PageType,
-            payment_models.Payment: payment_types.Payment,
-            payment_models.TransactionItem: payment_types.TransactionItem,
-            product_models.Category: product_types.Category,
-            product_models.Collection: product_types.Collection,
-            product_models.DigitalContent: product_types.DigitalContent,
-            product_models.Product: product_types.Product,
-            product_models.ProductMedia: product_types.ProductMedia,
-            product_models.ProductType: product_types.ProductType,
-            product_models.ProductVariant: product_types.ProductVariant,
-            shipping_models.ShippingMethod: shipping_types.ShippingMethodType,
-            shipping_models.ShippingZone: shipping_types.ShippingZone,
-            site_models.SiteSettings: shop_types.Shop,
-            tax_models.TaxClass: tax_types.TaxClass,
-            tax_models.TaxConfiguration: tax_types.TaxConfiguration,
-            warehouse_models.Warehouse: warehouse_types.Warehouse,
-        }
+    MODEL_TO_TYPE_MAP = {
+        account_models.Address: account_types.Address,
+        account_models.User: account_types.User,
+        app_models.App: app_types.App,
+        attribute_models.Attribute: attribute_types.Attribute,
+        channel_models.Channel: channel_types.Channel,
+        checkout_models.Checkout: checkout_types.Checkout,
+        checkout_models.CheckoutMetadata: checkout_types.Checkout,
+        checkout_models.CheckoutLine: checkout_types.CheckoutLine,
+        discount_models.Promotion: discount_types.Promotion,
+        discount_models.Voucher: discount_types.Voucher,
+        giftcard_models.GiftCard: giftcard_types.GiftCard,
+        invoice_models.Invoice: invoice_types.Invoice,
+        menu_models.Menu: menu_types.Menu,
+        menu_models.MenuItem: menu_types.MenuItem,
+        order_models.Fulfillment: order_types.Fulfillment,
+        order_models.Order: order_types.Order,
+        order_models.OrderLine: order_types.OrderLine,
+        page_models.Page: page_types.Page,
+        page_models.PageType: page_types.PageType,
+        payment_models.Payment: payment_types.Payment,
+        payment_models.TransactionItem: payment_types.TransactionItem,
+        product_models.Category: product_types.Category,
+        product_models.Collection: product_types.Collection,
+        product_models.DigitalContent: product_types.DigitalContent,
+        product_models.Product: product_types.Product,
+        product_models.ProductMedia: product_types.ProductMedia,
+        product_models.ProductType: product_types.ProductType,
+        product_models.ProductVariant: product_types.ProductVariant,
+        shipping_models.ShippingMethod: shipping_types.ShippingMethodType,
+        shipping_models.ShippingZone: shipping_types.ShippingZone,
+        site_models.SiteSettings: shop_types.Shop,
+        tax_models.TaxClass: tax_types.TaxClass,
+        tax_models.TaxConfiguration: tax_types.TaxConfiguration,
+        warehouse_models.Warehouse: warehouse_types.Warehouse,
+    }
+
+    if instance.__class__ in MODEL_TO_TYPE_MAP:
         if instance.__class__ == discount_models.Promotion and getattr(
-            instance, "old_sale_id"
+            instance, "old_sale_id", False
         ):
             return discount_types.Sale, instance.pk
         return MODEL_TO_TYPE_MAP.get(instance.__class__, None), instance.pk

--- a/saleor/graphql/product/types/collections.py
+++ b/saleor/graphql/product/types/collections.py
@@ -14,7 +14,7 @@ from ....thumbnail.utils import (
 )
 from ...channel import ChannelContext, ChannelQsContext
 from ...channel.dataloaders import ChannelBySlugLoader
-from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
+from ...channel.types import ChannelContextType
 from ...core import ResolveInfo
 from ...core.connection import (
     CountableConnection,
@@ -22,10 +22,7 @@ from ...core.connection import (
     filter_connection_queryset,
 )
 from ...core.context import get_database_connection_name
-from ...core.descriptions import (
-    DEPRECATED_IN_3X_FIELD,
-    RICH_CONTENT,
-)
+from ...core.descriptions import DEPRECATED_IN_3X_FIELD, RICH_CONTENT
 from ...core.doc_category import DOC_CATEGORY_PRODUCTS
 from ...core.federation import federated_entity
 from ...core.fields import FilterConnectionField, JSONString, PermissionsField
@@ -47,7 +44,7 @@ from .products import ProductCountableConnection
 
 
 @federated_entity("id channel")
-class Collection(ChannelContextTypeWithMetadata[models.Collection]):
+class Collection(ChannelContextType[models.Collection]):
     id = graphene.GlobalID(required=True, description="The ID of the collection.")
     seo_title = graphene.String(description="SEO title of the collection.")
     seo_description = graphene.String(description="SEO description of the collection.")

--- a/saleor/graphql/product/types/products.py
+++ b/saleor/graphql/product/types/products.py
@@ -47,7 +47,7 @@ from ...attribute.types import (
 )
 from ...channel import ChannelContext, ChannelQsContext
 from ...channel.dataloaders import ChannelBySlugLoader
-from ...channel.types import ChannelContextType, ChannelContextTypeWithMetadata
+from ...channel.types import ChannelContextType
 from ...channel.utils import get_default_channel_slug_or_graphql_error
 from ...core.connection import (
     CountableConnection,
@@ -262,7 +262,7 @@ class PreorderData(BaseObjectType):
 
 
 @federated_entity("id channel")
-class ProductVariant(ChannelContextTypeWithMetadata[models.ProductVariant]):
+class ProductVariant(ChannelContextType[models.ProductVariant]):
     id = graphene.GlobalID(required=True, description="The ID of the product variant.")
     name = graphene.String(
         required=True, description="The name of the product variant."
@@ -838,7 +838,7 @@ class ProductVariantCountableConnection(CountableConnection):
 
 
 @federated_entity("id channel")
-class Product(ChannelContextTypeWithMetadata[models.Product]):
+class Product(ChannelContextType[models.Product]):
     id = graphene.GlobalID(required=True, description="The ID of the product.")
     seo_title = graphene.String(description="SEO title of the product.")
     seo_description = graphene.String(description="SEO description of the product.")

--- a/saleor/graphql/shipping/types.py
+++ b/saleor/graphql/shipping/types.py
@@ -11,13 +11,7 @@ from ...shipping.interface import ShippingMethodData
 from ..account.enums import CountryCodeEnum
 from ..channel import ChannelQsContext
 from ..channel.dataloaders import ChannelByIdLoader
-from ..channel.types import (
-    Channel,
-    ChannelContext,
-    ChannelContextType,
-    ChannelContextTypeWithMetadata,
-    ChannelContextTypeWithMetadataForObjectType,
-)
+from ..channel.types import Channel, ChannelContext, ChannelContextType
 from ..core.connection import CountableConnection, create_connection_slice
 from ..core.context import get_database_connection_name
 from ..core.descriptions import DEPRECATED_IN_3X_FIELD, RICH_CONTENT
@@ -100,7 +94,7 @@ class ShippingMethodPostalCodeRule(
         model = models.ShippingMethodPostalCodeRule
 
 
-class ShippingMethodType(ChannelContextTypeWithMetadataForObjectType):
+class ShippingMethodType(ChannelContextType):
     """Represents internal shipping method managed within Saleor.
 
     Internal and external (fetched by sync webhooks) shipping methods are later
@@ -260,7 +254,7 @@ class ShippingMethodType(ChannelContextTypeWithMetadataForObjectType):
         )
 
 
-class ShippingZone(ChannelContextTypeWithMetadata[models.ShippingZone]):
+class ShippingZone(ChannelContextType[models.ShippingZone]):
     id = graphene.GlobalID(required=True, description="The ID of shipping zone.")
     name = graphene.String(required=True, description="Shipping zone name.")
     default = graphene.Boolean(


### PR DESCRIPTION
Recreated from original PR: https://github.com/saleor/saleor/pull/17282

I want to merge this change because it wraps the CheckoutLine on the resolvers into `SyncWebhookControlContext`. This allows us to store the info about blocking the sync webhooks. 
Additionally, some of the logic was cleaned up in this PR:
- I've dropped the `ChannelContextTypeWithMetadataForObjectType`, as it was the type to only provide the resovlers for Metadata. Right now this is embedded in Metadata type (previously Metadata type already had custom logic for ChannelContext). With this, an...